### PR TITLE
[SASU-0005] Changed statement to function

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -100,7 +100,7 @@ identifier_name:
 nesting:
   type_level:
     warning: 2
-  statement_level:
+  function_level:
     warning: 3
 
 switch_case_alignment:


### PR DESCRIPTION
to silence swiftlint warning 'statement_level' has been renamed to 'function_level' and will be completely removed in a future release.