### PR TITLE
[SASU-0076] - Mestro Github Actions Bugfix

### DIFF
--- a/.github/workflows/ios-build-check.yml
+++ b/.github/workflows/ios-build-check.yml
@@ -34,5 +34,4 @@ jobs:
         with:
           api-key: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
           app-file: build/SampleAppSwiftUI.app
-          pre-test-commands: |
-            maestro cloud --ios-version 16 SampleAppSwiftUI.app myflows/
+          ios-version: 16


### PR DESCRIPTION
## Description

Maestro Cloud currently supports the simulator for iOS 15.5, and the minimum target for sample application projects is iOS 16. As a result, the uitests GitHub actions failed. To resolve this issue, Maestro Cloud has been configured to work on the iOS 16 simulator.

## 

Related to:

#83

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
