### PR TITLE
[SASU-0093] - Searching and Sorting Option bug

### DIFF
--- a/SampleAppSwiftUI/Scenes/Favorites/FavoritesViewModel.swift
+++ b/SampleAppSwiftUI/Scenes/Favorites/FavoritesViewModel.swift
@@ -21,8 +21,8 @@ class FavoritesViewModel: ObservableObject {
     @Published var coinList: [CoinData] = []
     @Published var filteredCoins: [CoinData] = []
     @Published var coinInfo: CoinData?
-    @Published var filterTitle = SortOptions.mostPopular.rawValue
-    @Published var selectedSortOption: SortOptions = .mostPopular
+    @Published var filterTitle = SortOptions.defaultList.rawValue
+    @Published var selectedSortOption: SortOptions = .defaultList
 
     @State var isLoading: Bool = false
 

--- a/SampleAppSwiftUI/Scenes/Home/HomeViewModel.swift
+++ b/SampleAppSwiftUI/Scenes/Home/HomeViewModel.swift
@@ -13,8 +13,8 @@ class HomeViewModel: ObservableObject {
     @Published var coinInfo: ExcangeRatesResponseModel?
     @Published var coinList: [CoinData] = []
     @Published var filteredCoins: [CoinData] = []
-    @Published var filterTitle = SortOptions.mostPopular.rawValue
-    @Published var selectedSortOption: SortOptions = .mostPopular
+    @Published var filterTitle = SortOptions.defaultList.rawValue
+    @Published var selectedSortOption: SortOptions = .defaultList
 
     let listPageLimit = 10
     @State var isLoading: Bool = false

--- a/SampleAppSwiftUI/Scenes/Home/SortOptions.swift
+++ b/SampleAppSwiftUI/Scenes/Home/SortOptions.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public enum SortOptions: String, CaseIterable {
-    case mostPopular = "Most Popular"
+    case defaultList = "Default"
     case price = "Price (Low- High)"
     case priceReversed = "Price (High-Low)"
     case name = "Name (A-Z)"

--- a/SampleAppSwiftUI/Scenes/ViewModelProtocol.swift
+++ b/SampleAppSwiftUI/Scenes/ViewModelProtocol.swift
@@ -20,8 +20,8 @@ extension ViewModelProtocol {
     func checkLastItem(_ item: CoinData) {}
     func sortOptions(sort: SortOptions) {
         switch sort {
-            case .mostPopular:
-                filteredCoins = coinList
+            case .defaultList:
+                filteredCoins = filteredCoins.count < coinList.count ? filteredCoins : coinList
             case .price:
                 filteredCoins = filteredCoins.sorted {
                     $0.detail?.usd?.price ?? 0 < $1.detail?.usd?.price ?? 0


### PR DESCRIPTION
## Description

When the application was first opened and the user wanted to make a search, the filtered list did not appear on the screen. The reason for this was that instead of showing the filtered list, which is considered as default, the unfiltered list retrieved from the API was being displayed.

## Related issue

Related to:

## Explanation of changes

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
