### PR TITLE
[SASU-0091] Delete unnecessary body property from RequestObject

### DIFF
--- a/SampleAppSwiftUI/Network/Base/NetworkLoaderProtocol.swift
+++ b/SampleAppSwiftUI/Network/Base/NetworkLoaderProtocol.swift
@@ -40,7 +40,7 @@ extension NetworkLoaderProtocol {
         var request = URLRequest(url: url)
         request.httpMethod = requestObject.method.rawValue
         request.allHTTPHeaderFields = requestObject.headers
-        request.httpBody = requestObject.body
+        request.httpBody = requestObject.data?.encode()
 
         return request
     }

--- a/SampleAppSwiftUI/Network/Entities/RequestObject.swift
+++ b/SampleAppSwiftUI/Network/Entities/RequestObject.swift
@@ -13,18 +13,15 @@ struct RequestObject {
     let method: HTTPMethod
     var data: Encodable?
     var headers: [String: String]?
-    var body: Data?
 
     init(url: String,
          method: HTTPMethod = .get,
          data: Encodable? = nil,
-         headers: [String: String] = [:],
-         body: Data? = nil) {
+         headers: [String: String] = [:]) {
         self.url = url
         self.method = method
         self.data = data
         self.headers = headers
-        self.body = body
     }
 }
 


### PR DESCRIPTION
## Description

RequestObject struct has data (Encodable) and body (Data) properties that have a same purpose. They correspond encoded and not encoded version of the httpBody property of the URLRequest so body property is deleted from RequestObject and data property is encoded inside prepareURLRequest method.

## Related issue

Related to: #91

## Explanation of changes

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
